### PR TITLE
Restore CHICKEN 4 support

### DIFF
--- a/posix-shm.scm
+++ b/posix-shm.scm
@@ -41,12 +41,23 @@
 
  (posix-shm? shm-open shm-unlink)
 
- (import scheme (chicken base) (chicken foreign) (chicken blob)
-         (only (chicken string) ->string)
-         (only srfi-1 filter)
-         (only (chicken file posix) perm/irwxu perm/irgrp perm/iroth
-               open/rdonly open/rdwr open/creat open/excl open/trunc)
-	  )
+(import scheme)
+(cond-expand
+  (chicken-4
+     (import chicken foreign)
+     (require-library posix srfi-1)
+     (import (only srfi-1 filter)
+             (only posix perm/irwxu perm/irgrp perm/iroth
+                   open/rdonly open/rdwr open/creat open/excl open/trunc)))
+  (chicken-5
+   (import scheme (chicken base) (chicken foreign) (chicken blob)
+           (only (chicken string) ->string)
+           (only srfi-1 filter)
+           (only (chicken file posix) perm/irwxu perm/irgrp perm/iroth
+                 open/rdonly open/rdwr open/creat open/excl open/trunc)))
+  (else
+   (error "Unsupported CHICKEN version.")))
+
 
 ; Include into generated code, but don't parse:
 #>

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -1,4 +1,12 @@
-(import scheme (chicken format) (chicken random) (chicken file posix) (chicken string) posix-shm)
+(import scheme)
+(cond-expand
+  (chicken-4
+   (use posix-shm)
+   (define pseudo-random-integer random))
+  (chicken-5
+   (import scheme (chicken format) (chicken random) (chicken file posix) (chicken string) posix-shm))
+  (else
+   (error "Unsupported CHICKEN version.")))
 
 (define block-size 8)
 


### PR DESCRIPTION
The release-info file in this repository is referenced by
egg-locations for CHICKEN 4. that means that a new release based on
the current code would break the egg for CHICKEN 4.

This change makes the code compatible with both CHICKEN 4 and CHICKEN
5.