### PR TITLE
Drop dependency on srfi-13

### DIFF
--- a/build.scm
+++ b/build.scm
@@ -1,5 +1,5 @@
 
-(import (chicken base) (chicken format) (chicken process) (chicken process-context) srfi-1 srfi-13 compile-file)
+(import (chicken base) (chicken format) (chicken process) (chicken process-context) (chicken string) srfi-1 compile-file)
 (define args (command-line-arguments))
 
 
@@ -23,10 +23,9 @@
 
 (define c+ld-options (or (shm-test ("-lrt" "-DHAVE_POSIX_SHM")) ""))
 
-(define cmd (intersperse (append args (filter (lambda (x) x)
-                                              (list (sprintf "-L \"~A\"" (car c+ld-options))
-                                                    (and (> (string-length (cdr c+ld-options)) 0)
-                                                         (sprintf "-C \"~A\"" (cdr c+ld-options))))))
-                                 " "))
-(print (string-concatenate cmd))
-(system (string-concatenate cmd))
+(define cmd (append args (filter (lambda (x) x)
+                                 (list (sprintf "-L \"~A\"" (car c+ld-options))
+                                       (and (> (string-length (cdr c+ld-options)) 0)
+                                            (sprintf "-C \"~A\"" (cdr c+ld-options)))))))
+(print (string-intersperse cmd))
+(system (string-intersperse cmd))


### PR DESCRIPTION
srfi-13 was being used in `build.scm` but not declared as a
dependency.  This change simply replaces srfi-13, which was only used
for `string-concatenate`, with `string-intersperse` from
`chicken.string`.

Fixes
http://salmonella-linux-x86.call-cc.org/master-debugbuild/gcc/linux/x86/2021/03/28/salmonella-report/install/posix-shm.html